### PR TITLE
add `BulkAddMetadata` to add multiple metadatas at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ You can run them with:
 ```bash
 $ go run examples/addcoverimage.go
 $ go run examples/addmetadata.go
+$ go run examples/bulkaddmetadata.go
+$ go run examples/overwriteoriginalfile.go
 $ go run examples/readmetadata.go
 $ go run examples/removecoverimage.go
 $ go run examples/removemetadata.go

--- a/examples/bulkaddmetadata.go
+++ b/examples/bulkaddmetadata.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	flacgo "github.com/jacopo-degattis/flacgo"
+)
+
+func main() {
+	reader, err := flacgo.Open("examples/sample.flac")
+
+	if err != nil {
+		panic(err)
+	}
+
+	data, err := os.ReadFile("examples/test.jpg")
+
+	// You can either use this
+	err = reader.BulkAddMetadata(flacgo.FlacMetadatas{
+		Date:   "2002-12-02",
+		Artist: "Test Artist",
+		Album:  "Test Album",
+		Cover:  data,
+	})
+
+	// Or this
+	// err = reader.SetMetadata("Date", "2002-12-02")
+	// err = reader.SetMetadata("Artist", "Test Artist")
+	// err = reader.SetMetadata("Album", "Test Album")
+
+	if err != nil {
+		panic(err)
+	}
+
+	filename := "output.flac"
+	err = reader.Save(&filename)
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("[+] DONE")
+}

--- a/flac.go
+++ b/flac.go
@@ -46,6 +46,14 @@ type VorbisComment struct {
 	Value string
 }
 
+type FlacMetadatas struct {
+	Title  string
+	Artist string
+	Album  string
+	Date   string
+	Cover  []byte
+}
+
 // Flac is the main struct holding a pointer to the currently opened file
 type Flac struct {
 	file                *os.File
@@ -393,6 +401,32 @@ func (flac *Flac) SetMetadata(title string, value string) error {
 		Title: title,
 		Value: value,
 	})
+
+	return nil
+}
+
+func (flac *Flac) BulkAddMetadata(meta FlacMetadatas) error {
+	fields := map[string]string{
+		"title":  meta.Title,
+		"artist": meta.Artist,
+		"album":  meta.Album,
+		"date":   meta.Date,
+	}
+
+	for key, value := range fields {
+		if value == "" {
+			continue
+		}
+		if err := flac.SetMetadata(key, value); err != nil {
+			return fmt.Errorf("unable to set %s in BulkAddMetadata: %w", key, err)
+		}
+	}
+
+	if len(meta.Cover) > 0 {
+		if err := flac.SetCoverPictureFromBytes(meta.Cover); err != nil {
+			return fmt.Errorf("unable to set cover in BulkAddMetadata: %w", err)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
- also add new example to show off the new function